### PR TITLE
Require six>=1.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-requires = ['Django >= 1.4', 'six==1.4.1']
+requires = ['Django >= 1.4', 'six>=1.4.1']
 tests_require = requires
 
 setup(


### PR DESCRIPTION
Is a fixed version of six required. When I install dj-inmemorystorage, six-1.5.2 was uninstalled :(
