### PR TITLE
Add option for storage to be persistant

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ dj-inmemorystorage
 .. image:: https://travis-ci.org/waveaccounting/dj-inmemorystorage.png?branch=master
    :target: https://travis-ci.org/waveaccounting/dj-inmemorystorage
 
-A non-persistent in-memory data storage backend for Django.
+An in-memory data storage backend for Django.
 
 Compatible with Django's `storage API <https://docs.djangoproject.com/en/dev/ref/files/storage/>`_.
 
@@ -25,6 +25,17 @@ In your test settings file, add
 .. code:: python
 
     DEFAULT_FILE_STORAGE = 'inmemorystorage.InMemoryStorage'
+
+By default, the ``InMemoryStorage`` backend is non-persistant, meaning that
+writes to it from one section of your code will not be present when reading
+from another section of your code, unless both are sharing the same instance of
+the storage backend.
+
+If you need your storage to persist, you can add the following to your settings.
+
+.. code:: python
+
+    INMEMORYSTORAGE_PERSIST = True
 
 ===========
 Differences

--- a/inmemorystorage/storage.py
+++ b/inmemorystorage/storage.py
@@ -156,12 +156,18 @@ class InMemoryDir(InMemoryNode):
         return path
 
 
+_filesystem = InMemoryDir()
+
+
 class InMemoryStorage(Storage):
     """
     Django storage class for in-memory filesystem.
     """
     def __init__(self, filesystem=None, base_url=None):
-        self.filesystem = filesystem or InMemoryDir()
+        if not filesystem and getattr(settings, "INMEMORYSTORAGE_PERSIST", False):
+            self.filesystem = _filesystem
+        else:
+            self.filesystem = filesystem or InMemoryDir()
 
         if base_url is None:
             base_url = settings.MEDIA_URL

--- a/tests.py
+++ b/tests.py
@@ -141,6 +141,18 @@ class MemoryStorageTests(unittest.TestCase):
         after_write_created_time = self.storage.created_time('file')
         self.assertEqual(after_write_created_time, created_time)
 
+    @override_settings(INMEMORYSTORAGE_PERSIST=True)
+    def test_persistance(self):
+        storage_a = InMemoryStorage()
+        storage_b = InMemoryStorage()
+
+        assert storage_a.filesystem is storage_b.filesystem
+
+    def test_no_persistance_without_setting(self):
+        storage_a = InMemoryStorage()
+        storage_b = InMemoryStorage()
+
+        assert storage_a.filesystem is not storage_b.filesystem
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### What is the problem / feature ?

My primary use case for this library is to prevent my tests from poluting my filesystem when I need to test file related operations.  I've run into problems where I need to be able to verify writes to the storage backend.

### How did it get fixed / implemented ?

I added a new setting `INMEMORYSTORAGE_PERSIST` which defaults to `False`.  When *truthy*, the `InMemoryStorage` backend will instantiate itself with a filesystem object that is shared across instances and persists during the lifetime of the python process.

In addition, I've updated the `README` to reflect these changes and provide instructions on how to use this feature.

### How can someone test / see it ?

You can look at the two new tests I wrote, or set the new setting and verify that the `filesystem` property is the same object across multiple instances of the storage backend.

*Here is a cute animal picture for your troubles...*

![birdmouse](https://cloud.githubusercontent.com/assets/824194/6093689/d6fc76e6-aec6-11e4-9625-6e84bde6124f.jpg)
