### PR TITLE
Add support for windows

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,5 +1,6 @@
 # Keep the file alphabetically sorted
 
+Brian Grohe
 Charlie Denton
 Piper Merriam
 Simon Luijk

--- a/inmemorystorage/storage.py
+++ b/inmemorystorage/storage.py
@@ -91,7 +91,8 @@ class InMemoryDir(InMemoryNode):
         self.parent = parent
 
     def resolve(self, path, create=False, use_bytes=False):
-        path_bits = path.strip('/').split('/', 1)
+        path = os.path.normpath(path)
+        path_bits = path.strip(os.sep).split(os.sep, 1)
         current = path_bits[0]
         rest = path_bits[1] if len(path_bits) > 1 else None
         if not rest:

--- a/inmemorystorage/storage.py
+++ b/inmemorystorage/storage.py
@@ -96,7 +96,7 @@ class InMemoryDir(InMemoryNode):
         current = path_bits[0]
         rest = path_bits[1] if len(path_bits) > 1 else None
         if not rest:
-            if current == '':
+            if current == '.' or current == '':
                 return self
             if current in self.children.keys():
                 return self.children[current]

--- a/tests.py
+++ b/tests.py
@@ -25,7 +25,6 @@ class MemoryStorageTests(unittest.TestCase):
 
         self.filesystem.resolve('dir0').add_child('subdir', InMemoryDir())
         self.assertEqual(self.storage.listdir('dir0'), [['subdir'], []])
-        self.assertEqual(self.storage.listdir('dir0\\subdir'), [[], []])
         self.assertEqual(self.storage.listdir('dir0/subdir'), [[], []])
 
     def test_delete(self):

--- a/tests.py
+++ b/tests.py
@@ -25,6 +25,8 @@ class MemoryStorageTests(unittest.TestCase):
 
         self.filesystem.resolve('dir0').add_child('subdir', InMemoryDir())
         self.assertEqual(self.storage.listdir('dir0'), [['subdir'], []])
+        self.assertEqual(self.storage.listdir('dir0\\subdir'), [[], []])
+        self.assertEqual(self.storage.listdir('dir0/subdir'), [[], []])
 
     def test_delete(self):
         self.filesystem.add_child('dir0', InMemoryDir())


### PR DESCRIPTION
When testing on windows the file is saved with a `\` which is the default on windows. When the path is attempted to be opened in testing it explicitly looks for `/` which doesn't exist since the path is not normalized
