### PR TITLE
Don't guess the encoding, use UTF-8

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,5 +3,6 @@
 Brian Grohe
 Charlie Denton
 Piper Merriam
+René Fleschenberg
 Simon Luijk
 Zbigniew Siciarz

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import io
 from setuptools import setup
 
 requires = ['Django >= 1.4', 'six>=1.4.1']
@@ -10,7 +11,7 @@ setup(
     description="A non-persistent in-memory data storage backend for Django.",
     version="1.4.0",
     url="https://github.com/waveaccounting/dj-inmemorystorage",
-    license=open('LICENSE').read(),
+    license=io.open('LICENSE', encoding='utf-8').read(),
     long_description=open('README.rst').read(),
     author='Cody Soyland, Seán Hayes, Tore Birkeland, Nick Presta',
     author_email='opensource@waveapps.com',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     version="1.4.0",
     url="https://github.com/waveaccounting/dj-inmemorystorage",
     license=io.open('LICENSE', encoding='utf-8').read(),
-    long_description=open('README.rst').read(),
+    long_description=io.open('README.rst', encoding='utf-8').read(),
     author='Cody Soyland, Seán Hayes, Tore Birkeland, Nick Presta',
     author_email='opensource@waveapps.com',
     packages=[

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ tests_require = requires
 setup(
     name="dj-inmemorystorage",
     description="A non-persistent in-memory data storage backend for Django.",
-    version="1.4.0",
+    version="1.4.1",
     url="https://github.com/waveaccounting/dj-inmemorystorage",
     license=io.open('LICENSE', encoding='utf-8').read(),
     long_description=io.open('README.rst', encoding='utf-8').read(),


### PR DESCRIPTION
Installing dj-inmemorystorage fails on systems where the default encoding is ASCII, because the License file cannot be decoded in this case. I hit this on my CI runner.

I am not adding a test because the proper way to test this would probably be something like tox, and adding this seems outside the scope of this PR.

I manually verified that I can install the package on Python 2.7 and 3.5 with this change. I don't know if this will work on Python 2.6.