### PR TITLE
Fix unicode issue in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import io
 from setuptools import setup
 import sys
 
@@ -13,7 +12,7 @@ def _read_file_py2_compat(filename):
     # Assumes the file is encoded with utf-8.
     if sys.version_info < (3,):
         return open(filename).read()
-    return io.open(filename, encoding='utf-8').read()
+    return open(filename, encoding='utf-8').read()
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def _read_file_py2_compat(filename):
 setup(
     name="dj-inmemorystorage",
     description="A non-persistent in-memory data storage backend for Django.",
-    version="1.4.0",
+    version="1.4.1",
     url="https://github.com/waveaccounting/dj-inmemorystorage",
     license=_read_file_py2_compat('LICENSE'),
     long_description=_read_file_py2_compat('README.rst'),

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,28 @@
 # -*- coding: utf-8 -*-
 
+import io
 from setuptools import setup
+import sys
 
 requires = ['Django >= 1.4', 'six>=1.4.1']
 tests_require = requires
+
+
+def _read_file_py2_compat(filename):
+    # Return str (bytestring) on Python 2, str (unicode string) on Python 3.
+    # Assumes the file is encoded with utf-8.
+    if sys.version_info < (3,):
+        return open(filename).read()
+    return io.open(filename, encoding='utf-8').read()
+
 
 setup(
     name="dj-inmemorystorage",
     description="A non-persistent in-memory data storage backend for Django.",
     version="1.4.0",
     url="https://github.com/waveaccounting/dj-inmemorystorage",
-    license=open('LICENSE').read(),
-    long_description=open('README.rst').read(),
+    license=_read_file_py2_compat('LICENSE'),
+    long_description=_read_file_py2_compat('README.rst'),
     author='Cody Soyland, Seán Hayes, Tore Birkeland, Nick Presta',
     author_email='opensource@waveapps.com',
     packages=[


### PR DESCRIPTION
Next attempt to solve the issue from PR #12.

I am really not sure if this is the correct fix, but after a quick test, my impression was that Python 3 wants these to be `str` (unicode), while Python 2 wants them to be `str` (bytestring).

You might want to give this more testing or discussion before you merge it.
