### PR TITLE
Add note to README.md that InMemoryStorage is part of Django now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+`InMemoryStorage` is part of Django 4.2 now ([added in PR #16161](https://github.com/django/django/pull/16262)).
+
 # dj-inmemorystorage
 
 [![image](https://travis-ci.org/waveaccounting/dj-inmemorystorage.png?branch=master)](https://travis-ci.org/waveaccounting/dj-inmemorystorage)


### PR DESCRIPTION
I think it's nice to make users aware of the fact that `InMemoryStorage` is now part of Django.